### PR TITLE
Fixups for hydra-evaluator Rust rewrite (NixOS/hydra#1605)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,6 +1492,7 @@ dependencies = [
  "anyhow",
  "clap",
  "db",
+ "fs-err",
  "futures",
  "hydra-tracing",
  "sqlx",

--- a/nixos-modules/web-app.nix
+++ b/nixos-modules/web-app.nix
@@ -266,7 +266,7 @@ in
         requires = [ "hydra-init.service" ];
         restartTriggers = [ hydraConf ];
         after = [ "hydra-init.service" "network.target" ];
-        path = with pkgs; [ hostname-debian ];
+        path = with pkgs; [ hostname-debian cfg.package ];
         environment = env // {
           HYDRA_DBI = "${env.HYDRA_DBI};application_name=hydra-evaluator";
         };

--- a/subprojects/hydra-evaluator/Cargo.toml
+++ b/subprojects/hydra-evaluator/Cargo.toml
@@ -12,6 +12,7 @@ clap = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 futures.workspace = true
+fs-err.workspace = true
 sqlx = { workspace = true, features = [
   "runtime-tokio",
   "tls-rustls-ring-webpki",

--- a/subprojects/hydra-evaluator/src/config.rs
+++ b/subprojects/hydra-evaluator/src/config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use anyhow::{Context as _, bail};
-use sqlx::postgres::PgConnectOptions;
+use anyhow::Context as _;
+use sqlx::postgres::{PgConnectOptions, PgSslMode};
 
 #[derive(Debug)]
 pub(crate) struct HydraConfig {
@@ -92,8 +92,23 @@ fn parse_dbi(dbi: &str) -> anyhow::Result<PgConnectOptions> {
             "user" => opts = opts.username(value.trim()),
             "password" => opts = opts.password(value.trim()),
             "application_name" => opts = opts.application_name(value.trim()),
+            "sslmode" => {
+                let mode = match value.trim() {
+                    "disable" => PgSslMode::Disable,
+                    "allow" => PgSslMode::Allow,
+                    "prefer" => PgSslMode::Prefer,
+                    "require" => PgSslMode::Require,
+                    "verify-ca" => PgSslMode::VerifyCa,
+                    "verify-full" => PgSslMode::VerifyFull,
+                    v => anyhow::bail!("invalid sslmode: {v}"),
+                };
+                opts = opts.ssl_mode(mode);
+            }
+            "sslrootcert" => opts = opts.ssl_root_cert(value.trim()),
+            "sslcert" => opts = opts.ssl_client_cert(value.trim()),
+            "sslkey" => opts = opts.ssl_client_key(value.trim()),
             other => {
-                bail!("unknown DBI parameter: {other}");
+                tracing::warn!("ignoring unsupported DBI parameter: {other}");
             }
         }
     }

--- a/subprojects/hydra-evaluator/src/config.rs
+++ b/subprojects/hydra-evaluator/src/config.rs
@@ -17,7 +17,7 @@ impl HydraConfig {
             _ => return Self { options },
         };
 
-        let contents = match std::fs::read_to_string(&path) {
+        let contents = match fs_err::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {
                 tracing::warn!("could not read HYDRA_CONFIG at {path}: {e}");

--- a/subprojects/hydra-evaluator/src/evaluator.rs
+++ b/subprojects/hydra-evaluator/src/evaluator.rs
@@ -66,7 +66,8 @@ impl Evaluator {
         config: &HydraConfig,
         eval_one: Option<(String, String)>,
     ) -> Self {
-        let max_evals = config.get_int("max_concurrent_evals", 4).max(1) as usize;
+        let max_evals = usize::try_from(config.get_int("max_concurrent_evals", 4).max(1))
+            .unwrap_or(usize::MAX);
         Self {
             db,
             max_evals,
@@ -170,11 +171,8 @@ impl Evaluator {
             }
         }
 
-        if sleep_secs == i64::MAX {
-            Duration::MAX
-        } else {
-            Duration::from_secs(sleep_secs as u64)
-        }
+        u64::try_from(sleep_secs)
+            .map_or(Duration::MAX, Duration::from_secs)
     }
 
     async fn db_monitor_task(&self) {
@@ -237,10 +235,10 @@ impl Evaluator {
         let mut seen = HashSet::new();
 
         for row in &rows {
-            if let Some((ref proj, ref js)) = self.eval_one {
-                if row.project != *proj || row.name != *js {
-                    continue;
-                }
+            if let Some((ref proj, ref js)) = self.eval_one
+                && (row.project != *proj || row.name != *js)
+            {
+                continue;
             }
 
             seen.insert(row.id);
@@ -443,7 +441,7 @@ impl Evaluator {
         );
 
         sqlx::query("UPDATE Jobsets SET startTime = $1 WHERE id = $2")
-            .bind(now as i32)
+            .bind(now_epoch_i32())
             .bind(jobset_id)
             .execute(self.db.pool())
             .await
@@ -557,7 +555,7 @@ async fn update_db_after_eval(
              errorTime = $2, fetchErrorMsg = null WHERE id = $3",
         )
         .bind(format!("evaluation {status_str}"))
-        .bind(now as i32)
+        .bind(i32::try_from(now).unwrap_or(i32::MAX))
         .bind(jobset_id)
         .execute(&mut *txn)
         .await?;
@@ -570,15 +568,23 @@ async fn update_db_after_eval(
 fn now_epoch() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs() as i64)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_secs()).ok())
+        .unwrap_or(0)
+}
+
+/// Current epoch narrowed to the INT4 width used by Hydra's schema.
+/// Saturates at `i32::MAX` (the schema has a pre-existing Y2038 limit).
+fn now_epoch_i32() -> i32 {
+    i32::try_from(now_epoch()).unwrap_or(i32::MAX)
 }
 
 fn is_broken_connection(e: &anyhow::Error) -> bool {
     for cause in e.chain() {
-        if let Some(sqlx_err) = cause.downcast_ref::<sqlx::Error>() {
-            if matches!(sqlx_err, sqlx::Error::Io(_) | sqlx::Error::PoolClosed) {
-                return true;
-            }
+        if let Some(sqlx_err) = cause.downcast_ref::<sqlx::Error>()
+            && matches!(sqlx_err, sqlx::Error::Io(_) | sqlx::Error::PoolClosed)
+        {
+            return true;
         }
     }
     false

--- a/subprojects/hydra-evaluator/src/evaluator.rs
+++ b/subprojects/hydra-evaluator/src/evaluator.rs
@@ -259,8 +259,8 @@ impl Evaluator {
 
             jobset.project.clone_from(&row.project);
             jobset.name.clone_from(&row.name);
-            jobset.last_checked_time = row.lastcheckedtime.unwrap_or(0);
-            jobset.trigger_time = row.triggertime;
+            jobset.last_checked_time = row.lastcheckedtime.map_or(0, i64::from);
+            jobset.trigger_time = row.triggertime.map(i64::from);
             jobset.check_interval = row.checkinterval.into();
             jobset.evaluation_style = evaluation_style;
         }
@@ -589,8 +589,8 @@ struct JobsetRow {
     id: i32,
     project: String,
     name: String,
-    lastcheckedtime: Option<i64>,
-    triggertime: Option<i64>,
+    lastcheckedtime: Option<i32>,
+    triggertime: Option<i32>,
     checkinterval: i32,
     jobset_enabled: i32,
 }

--- a/subprojects/hydra-evaluator/src/evaluator.rs
+++ b/subprojects/hydra-evaluator/src/evaluator.rs
@@ -534,7 +534,7 @@ async fn update_db_after_eval(
     status_str: &str,
     now: i64,
 ) -> anyhow::Result<()> {
-    let pool = db.pool();
+    let mut txn = db.pool().begin().await?;
 
     // Clear trigger time to prevent stuck eval loop
     sqlx::query(
@@ -542,13 +542,13 @@ async fn update_db_after_eval(
          WHERE id = $1 AND startTime IS NOT NULL AND triggerTime <= startTime",
     )
     .bind(jobset_id)
-    .execute(pool)
+    .execute(&mut *txn)
     .await?;
 
     // Clear start time
     sqlx::query("UPDATE Jobsets SET startTime = null WHERE id = $1")
         .bind(jobset_id)
-        .execute(pool)
+        .execute(&mut *txn)
         .await?;
 
     if !exit_ok {
@@ -559,10 +559,11 @@ async fn update_db_after_eval(
         .bind(format!("evaluation {status_str}"))
         .bind(now as i32)
         .bind(jobset_id)
-        .execute(pool)
+        .execute(&mut *txn)
         .await?;
     }
 
+    txn.commit().await?;
     Ok(())
 }
 


### PR DESCRIPTION
Review fixups for https://github.com/NixOS/hydra/pull/1605 — ready to `git rebase -i --autosquash d6ebaa8^`.

### Bugs fixed
- **`hydra-eval-jobset` missing from PATH**: `cfg.package` was removed from the systemd unit's `path`, so `Command::new("hydra-eval-jobset")` would fail with ENOENT on every evaluation.
- **sqlx INT4 decode error**: `JobsetRow.{lastcheckedtime,triggertime}` were `Option<i64>` but the schema is `integer`; sqlx-postgres is strict and `read_jobsets()` would error at runtime.
- **Lost transaction in post-eval updates**: three `UPDATE`s that the C++ wrapped in a single `pqxx::work` were executed separately; partial failure could leave `startTime` set and the jobset stuck.
- **DBI parser too strict**: `sslmode`/`sslrootcert`/`sslcert`/`sslkey` now map to `PgConnectOptions`; unknown params warn instead of `bail!` so existing `HYDRA_DBI` strings keep working.
- **Clippy**: crate declares `#![deny(clippy::pedantic)]` but didn't pass it (`fs_err`, `try_from` casts, collapsible `if let`).

Verified with `cargo check` and `cargo clippy -- -D warnings`.